### PR TITLE
Hdf5 split

### DIFF
--- a/nideep/iow/to_hdf5.py
+++ b/nideep/iow/to_hdf5.py
@@ -41,17 +41,10 @@ def split_hdf5(fpath_src, dir_dst, tot_floats=(20 * 1024 * 1024)):
             fpath_dst = os.path.join(dir_dst, '%s_%03d%s' % (name_,
                                                              split_count,
                                                              ext))
-            if num_saved == 0:
-                h_dst = h5py.File(fpath_dst, 'w')
-            else:
-                h_dst = h5py.File(fpath_dst, 'a')
-
-            for key in keys:
-                h_dst[key] = h_src[key][num_saved:num_saved + split_sz]
-
-            dst_paths.append(fpath_dst)
-
-            h_dst.close()
+            with h5py.File(fpath_dst, ['a', 'w'][num_saved == 0]) as h_dst:
+                for key in keys:
+                    h_dst[key] = h_src[key][num_saved:num_saved + split_sz]
+                dst_paths.append(fpath_dst)
             num_saved += split_sz
             split_count += 1
 

--- a/nideep/nets/net_merge.py
+++ b/nideep/nets/net_merge.py
@@ -18,7 +18,7 @@ def merge_indep_net_spec(net_specs, suffix_fmt='_nidx_%02d'):
         suffix = suffix_fmt % idx
         throw_away = []
         for l in n.layer:
-            if l.type.lower() != 'data':
+            if l.type.lower() != 'data' or l.type.lower() != 'hdf5data':
 
                 l.name += suffix
 


### PR DESCRIPTION
clean up splitting of hdf5 files into multiple, enable non duplication of HDFData layers when merging network definitions.